### PR TITLE
add copy icon in code blocks

### DIFF
--- a/docs/copy-to-clipboard.js
+++ b/docs/copy-to-clipboard.js
@@ -1,0 +1,81 @@
+;(function () {
+    'use strict'
+  
+    var CMD_RX = /^\$ (\S[^\\\n]*(\\\n(?!\$ )[^\\\n]*)*)(?=\n|$)/gm
+    var LINE_CONTINUATION_RX = /( ) *\\\n *|\\\n( ?) */g
+    var TRAILING_SPACE_RX = / +$/gm
+  
+    var config = (document.getElementById('site-script') || { dataset: {} }).dataset
+    var uiRootPath = config.uiRootPath == null ? '.' : config.uiRootPath
+    var svgAs = config.svgAs
+    var supportsCopy = window.navigator.clipboard
+  
+    ;[].slice.call(document.querySelectorAll('.doc pre.highlight, .doc .literalblock pre')).forEach(function (pre) {
+      var code, language, lang, copy, toast, toolbox
+      if (pre.classList.contains('highlight')) {
+        code = pre.querySelector('code')
+        if ((language = code.dataset.lang) && language !== 'console') {
+          ;(lang = document.createElement('span')).className = 'source-lang'
+          lang.appendChild(document.createTextNode(language))
+        }
+      } else if (pre.innerText.startsWith('$ ')) {
+        var block = pre.parentNode.parentNode
+        block.classList.remove('literalblock')
+        block.classList.add('listingblock')
+        pre.classList.add('highlightjs', 'highlight')
+        ;(code = document.createElement('code')).className = 'language-console hljs'
+        code.dataset.lang = 'console'
+        code.appendChild(pre.firstChild)
+        pre.appendChild(code)
+      } else {
+        return
+      }
+      ;(toolbox = document.createElement('div')).className = 'source-toolbox'
+      if (lang) toolbox.appendChild(lang)
+      if (supportsCopy) {
+        ;(copy = document.createElement('button')).className = 'copy-button'
+        copy.setAttribute('title', 'Copy to clipboard')
+        if (svgAs === 'svg') {
+          var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+          svg.setAttribute('class', 'copy-icon')
+          var use = document.createElementNS('http://www.w3.org/2000/svg', 'use')
+          use.setAttribute('href', uiRootPath + '/images/octicons-16.svg#icon-clippy')
+          svg.appendChild(use)
+          copy.appendChild(svg)
+        } else {
+          var img = document.createElement('img')
+          img.src = uiRootPath + '/images/octicons-16.svg#view-clippy'
+          img.alt = 'copy icon'
+          img.className = 'copy-icon'
+          copy.appendChild(img)
+        }
+        ;(toast = document.createElement('span')).className = 'copy-toast'
+        toast.appendChild(document.createTextNode('Copied!'))
+        copy.appendChild(toast)
+        toolbox.appendChild(copy)
+      }
+      pre.parentNode.appendChild(toolbox)
+      if (copy) copy.addEventListener('click', writeToClipboard.bind(copy, code))
+    })
+  
+    function extractCommands (text) {
+      var cmds = []
+      var m
+      while ((m = CMD_RX.exec(text))) cmds.push(m[1].replace(LINE_CONTINUATION_RX, '$1$2'))
+      return cmds.join(' && ')
+    }
+  
+    function writeToClipboard (code) {
+      var text = code.innerText.replace(TRAILING_SPACE_RX, '')
+      if (code.dataset.lang === 'console' && text.startsWith('$ ')) text = extractCommands(text)
+      window.navigator.clipboard.writeText(text).then(
+        function () {
+          this.classList.add('clicked')
+          this.offsetHeight // eslint-disable-line no-unused-expressions
+          this.classList.remove('clicked')
+        }.bind(this),
+        function () {}
+      )
+    }
+  })()
+  

--- a/docs/docinfo-footer.html
+++ b/docs/docinfo-footer.html
@@ -1,0 +1,94 @@
+<style>
+    .doc .listingblock > .content {
+      position: relative;
+    }
+    
+    .doc .listingblock code[data-lang]::before {
+      content: none;
+    }
+    
+    .doc .source-toolbox {
+      display: flex;
+      position: absolute;
+      visibility: hidden;
+      top: 0.25rem;
+      right: 0.5rem;
+      color: #808080;
+      white-space: nowrap;
+      font-size: 0.85em;
+    }
+    
+    .doc .listingblock:hover .source-toolbox {
+      visibility: visible;
+    }
+    
+    .doc .source-toolbox .source-lang {
+      font-family: "Droid Sans Mono", "DejaVu Sans Mono", monospace;
+      text-transform: uppercase;
+      letter-spacing: 0.075em;
+    }
+    
+    .doc .source-toolbox > :not(:last-child)::after {
+      content: "|";
+      letter-spacing: 0;
+      padding: 0 1ch;
+    }
+    
+    .doc .source-toolbox .copy-button {
+      cursor: pointer;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      background: none;
+      border: none;
+      color: inherit;
+      outline: none;
+      padding: 0;
+      font-family: inherit;
+      font-size: inherit;
+      line-height: inherit;
+      width: 1em;
+      height: 1em;
+    }
+    
+    .doc .source-toolbox .copy-icon {
+      flex: none;
+      width: inherit;
+      height: inherit;
+      filter: invert(50.2%);
+      margin-top: 0.05em;
+    }
+    
+    .doc .source-toolbox .copy-toast {
+      flex: none;
+      position: relative;
+      display: inline-flex;
+      justify-content: center;
+      margin-top: 1em;
+      border-radius: 0.25em;
+      padding: 0.5em;
+      cursor: auto;
+      opacity: 0;
+      transition: opacity 0.5s ease 0.75s;
+      background: rgba(0, 0, 0, 0.8);
+      color: #fff;
+    }
+    
+    .doc .source-toolbox .copy-toast::after {
+      content: "";
+      position: absolute;
+      top: 0;
+      width: 1em;
+      height: 1em;
+      border: 0.55em solid transparent;
+      border-left-color: rgba(0, 0, 0, 0.8);
+      transform: rotate(-90deg) translateX(50%) translateY(50%);
+      transform-origin: left;
+    }
+    
+    .doc .source-toolbox .copy-button.clicked .copy-toast {
+      opacity: 1;
+      transition: none;
+    }
+    </style>
+    <script src="copy-to-clipboard.js"></script>

--- a/docs/images/octicons-16.svg
+++ b/docs/images/octicons-16.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <title>Octicons (16px subset)</title>
+  <desc>Octicons v11.2.0 by GitHub - https://primer.style/octicons/ - License: MIT</desc>
+  <metadata
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:cc="http://creativecommons.org/ns#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:title>@primer/octicons</dc:title>
+        <dc:identifier>11.2.0</dc:identifier>
+        <dc:description>A scalable set of icons handcrafted with &lt;3 by GitHub</dc:description>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>GitHub</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>Copyright (c) 2020 GitHub Inc.</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license rdf:resource="https://opensource.org/licenses/MIT" />
+        <dc:relation>https://primer.style/octicons/</dc:relation>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <symbol id="icon-clippy" viewBox="0 0 16 16">
+    <path
+       fill-rule="evenodd"
+       d="M5.75 1a.75.75 0 00-.75.75v3c0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75v-3a.75.75 0 00-.75-.75h-4.5zm.75 3V2.5h3V4h-3zm-2.874-.467a.75.75 0 00-.752-1.298A1.75 1.75 0 002 3.75v9.5c0 .966.784 1.75 1.75 1.75h8.5A1.75 1.75 0 0014 13.25v-9.5a1.75 1.75 0 00-.874-1.515.75.75 0 10-.752 1.298.25.25 0 01.126.217v9.5a.25.25 0 01-.25.25h-8.5a.25.25 0 01-.25-.25v-9.5a.25.25 0 01.126-.217z" />
+  </symbol>
+  <use href="#icon-clippy" width="16" height="16" x="0" y="0" />
+  <view id="view-clippy" viewBox="0 0 16 16" />
+</svg>

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -39,6 +39,14 @@ Codificación, idioma, tabla de contenidos, tipo de documento
 
 // :leveloffset: 1
 
+////
+///  Copy button on code blocks
+////
+[.doc]
+
+:docinfo: shared-footer
+
+
 //includes
 :section: ROOT
 :sectionPath: modules/{section}/pages


### PR DESCRIPTION
3 archivos añadidos (`copy-to-clipboard.js`, `docinfo-footer.html`, e `images/octicons-16.svg`), y una pequeña etiqueta en la cabecera del .adoc: 

```
////
///  Copy button on code blocks
////
[.doc]

:docinfo: shared-footer
```

Resultado: 
![image](https://user-images.githubusercontent.com/11983068/233326109-5fcaf429-2754-4f73-b9ae-dc56691fee74.png)
